### PR TITLE
Add currency field to user model

### DIFF
--- a/src/models/user.py
+++ b/src/models/user.py
@@ -12,6 +12,7 @@ class User(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    currency = db.Column(db.String(10), default='USD', nullable=False)
     expenses = db.relationship('Expense', backref='user', lazy=True, cascade="all, delete-orphan")
     budgets = db.relationship('Budget', backref='user', lazy=True, cascade="all, delete-orphan")
     
@@ -26,5 +27,6 @@ class User(db.Model):
             'id': self.id,
             'username': self.username,
             'email': self.email,
+            'currency': self.currency,
             'created_at': self.created_at.isoformat()
         }

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -53,7 +53,8 @@ def register():
     # Create new user
     new_user = User(
         username=data['username'],
-        email=data['email']
+        email=data['email'],
+        currency=data.get('currency', 'USD')
     )
     new_user.set_password(data['password'])
     
@@ -107,6 +108,9 @@ def update_profile(current_user):
     
     if data.get('password'):
         current_user.set_password(data['password'])
+
+    if data.get('currency') and data['currency'] != current_user.currency:
+        current_user.currency = data['currency']
     
     db.session.commit()
     


### PR DESCRIPTION
## Summary
- add `currency` column to the `User` model
- include currency in `to_dict`
- allow specifying currency on registration
- allow updating currency in profile updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fe29cd6788320930f3d2db40b3326