### PR TITLE
Add currency symbol helper

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -22,8 +22,11 @@ document.addEventListener("DOMContentLoaded", function () {
 	// Set up event listeners
 	setupEventListeners();
 
-	// Set default date for expense form
-	document.getElementById("expense-date").valueAsDate = new Date();
+        // Set default date for expense form
+        document.getElementById("expense-date").valueAsDate = new Date();
+
+        // Initialize currency symbols with default or user currency
+        updateCurrencySymbols();
 });
 
 // Setup all event listeners
@@ -114,7 +117,8 @@ function handleLogin(e) {
 				// Save token and user data
 				token = data.token;
 				localStorage.setItem("token", token);
-				currentUser = data.user;
+                                currentUser = data.user;
+                                updateCurrencySymbols();
 
 				// Show dashboard
 				showDashboard();
@@ -208,11 +212,12 @@ function fetchUserProfile() {
 			}
 			return response.json();
 		})
-		.then((data) => {
-			currentUser = data;
-			showDashboard();
-			loadDashboardData();
-		})
+                .then((data) => {
+                        currentUser = data;
+                        updateCurrencySymbols();
+                        showDashboard();
+                        loadDashboardData();
+                })
 		.catch((error) => {
 			console.error("Profile fetch error:", error);
 			// Token invalid, show auth section
@@ -2066,8 +2071,21 @@ function showUserProfile(e) {
 }
 
 // Utility functions
+function getCurrencySymbol(currency) {
+        const symbols = {
+                USD: "$",
+                LKR: "Rs",
+                EUR: "€",
+                GBP: "£",
+        };
+        return symbols[currency] || "$";
+}
+
 function formatCurrency(amount) {
-	return "$" + amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, "$&,");
+        const symbol = getCurrencySymbol(currentUser && currentUser.currency);
+        return (
+                symbol + amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, "$&,")
+        );
 }
 
 function formatDate(date) {
@@ -2103,7 +2121,14 @@ function getRandomColor(index) {
 		"#FFAA33",
 		"#808080",
 	];
-	return colors[index % colors.length];
+        return colors[index % colors.length];
+}
+
+function updateCurrencySymbols() {
+        const symbol = getCurrencySymbol(currentUser && currentUser.currency);
+        document.querySelectorAll(".currency-symbol").forEach((el) => {
+                el.textContent = symbol;
+        });
 }
 
 function toggleCustomDateRange() {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -130,7 +130,7 @@
                                 <div class="card bg-primary text-white">
                                     <div class="card-body">
                                         <h5 class="card-title">Total Expenses</h5>
-                                        <h2 class="card-text" id="total-expenses">$0.00</h2>
+                                        <h2 class="card-text" id="total-expenses"><span class="currency-symbol"></span>0.00</h2>
                                         <p class="card-text"><small id="expense-period">This month</small></p>
                                     </div>
                                 </div>
@@ -139,7 +139,7 @@
                                 <div class="card bg-success text-white">
                                     <div class="card-body">
                                         <h5 class="card-title">Budget Remaining</h5>
-                                        <h2 class="card-text" id="budget-remaining">$0.00</h2>
+                                        <h2 class="card-text" id="budget-remaining"><span class="currency-symbol"></span>0.00</h2>
                                         <p class="card-text"><small id="budget-period">This month</small></p>
                                     </div>
                                 </div>
@@ -476,7 +476,7 @@
                                 <div class="mb-3">
                                     <label for="expense-amount" class="form-label">Amount</label>
                                     <div class="input-group">
-                                        <span class="input-group-text">$</span>
+                                        <span class="input-group-text currency-symbol"></span>
                                         <input type="number" class="form-control" id="expense-amount" step="0.01" min="0.01" required>
                                     </div>
                                 </div>
@@ -518,7 +518,7 @@
                                 <div class="mb-3">
                                     <label for="edit-expense-amount" class="form-label">Amount</label>
                                     <div class="input-group">
-                                        <span class="input-group-text">$</span>
+                                        <span class="input-group-text currency-symbol"></span>
                                         <input type="number" class="form-control" id="edit-expense-amount" step="0.01" min="0.01" required>
                                     </div>
                                 </div>
@@ -564,7 +564,7 @@
                                 <div class="mb-3">
                                     <label for="budget-amount" class="form-label">Amount</label>
                                     <div class="input-group">
-                                        <span class="input-group-text">$</span>
+                                        <span class="input-group-text currency-symbol"></span>
                                         <input type="number" class="form-control" id="budget-amount" step="0.01" min="0.01" required>
                                     </div>
                                 </div>
@@ -622,7 +622,7 @@
                                 <div class="mb-3">
                                     <label for="edit-budget-amount" class="form-label">Amount</label>
                                     <div class="input-group">
-                                        <span class="input-group-text">$</span>
+                                        <span class="input-group-text currency-symbol"></span>
                                         <input type="number" class="form-control" id="edit-budget-amount" step="0.01" min="0.01" required>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- add `getCurrencySymbol` and `updateCurrencySymbols` helpers
- use the current user's currency when formatting amounts
- inject dynamic currency symbols in HTML
- update symbols on login or profile load

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fe39049dc8320ac0b267fe4b1c798