### PR TITLE
Revamp auth section layout

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -14,55 +14,58 @@
             <!-- Login/Register Section -->
             <div id="auth-section" class="container mt-5">
                 <div class="row justify-content-center">
-                    <div class="col-md-6">
+                    <div class="col-md-8">
                         <div class="card shadow">
-                            <div class="card-body">
-                                <ul class="nav nav-tabs" id="authTabs" role="tablist">
-                                    <li class="nav-item" role="presentation">
-                                        <button class="nav-link active" id="login-tab" data-bs-toggle="tab" data-bs-target="#login" type="button" role="tab" aria-controls="login"
-                                            aria-selected="true">Login</button>
-                                    </li>
-                                    <li class="nav-item" role="presentation">
-                                        <button class="nav-link" id="register-tab" data-bs-toggle="tab" data-bs-target="#register" type="button" role="tab" aria-controls="register"
-                                            aria-selected="false">Register</button>
-                                    </li>
-                                </ul>
-                                <div class="tab-content mt-3" id="authTabsContent">
-                                    <div class="tab-pane fade show active" id="login" role="tabpanel" aria-labelledby="login-tab">
-                                        <form id="login-form">
-                                            <div class="mb-3">
-                                                <label for="login-username" class="form-label">Username</label>
-                                                <input type="text" class="form-control" id="login-username" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label for="login-password" class="form-label">Password</label>
-                                                <input type="password" class="form-control" id="login-password" required>
-                                            </div>
-                                            <div class="alert alert-danger d-none" id="login-error"></div>
-                                            <button type="submit" class="btn btn-primary w-100">Login</button>
-                                        </form>
-                                    </div>
-                                    <div class="tab-pane fade" id="register" role="tabpanel" aria-labelledby="register-tab">
-                                        <form id="register-form">
-                                            <div class="mb-3">
-                                                <label for="register-username" class="form-label">Username</label>
-                                                <input type="text" class="form-control" id="register-username" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label for="register-email" class="form-label">Email</label>
-                                                <input type="email" class="form-control" id="register-email" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label for="register-password" class="form-label">Password</label>
-                                                <input type="password" class="form-control" id="register-password" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label for="register-confirm-password" class="form-label">Confirm Password</label>
-                                                <input type="password" class="form-control" id="register-confirm-password" required>
-                                            </div>
-                                            <div class="alert alert-danger d-none" id="register-error"></div>
-                                            <button type="submit" class="btn btn-primary w-100">Register</button>
-                                        </form>
+                            <div class="row g-0">
+                                <div class="col-md-6 d-none d-md-block">
+                                    <img src="https://via.placeholder.com/400" class="img-fluid auth-image" />
+                                </div>
+                                <div class="col-md-6 p-4">
+                                    <ul class="nav nav-tabs" id="authTabs" role="tablist">
+                                        <li class="nav-item" role="presentation">
+                                            <button class="nav-link active" id="login-tab" data-bs-toggle="tab" data-bs-target="#login" type="button" role="tab" aria-controls="login" aria-selected="true">Login</button>
+                                        </li>
+                                        <li class="nav-item" role="presentation">
+                                            <button class="nav-link" id="register-tab" data-bs-toggle="tab" data-bs-target="#register" type="button" role="tab" aria-controls="register" aria-selected="false">Register</button>
+                                        </li>
+                                    </ul>
+                                    <div class="tab-content mt-3" id="authTabsContent">
+                                        <div class="tab-pane fade show active" id="login" role="tabpanel" aria-labelledby="login-tab">
+                                            <form id="login-form">
+                                                <div class="mb-3">
+                                                    <label for="login-username" class="form-label">Username</label>
+                                                    <input type="text" class="form-control" id="login-username" required>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label for="login-password" class="form-label">Password</label>
+                                                    <input type="password" class="form-control" id="login-password" required>
+                                                </div>
+                                                <div class="alert alert-danger d-none" id="login-error"></div>
+                                                <button type="submit" class="btn btn-primary w-100">Login</button>
+                                            </form>
+                                        </div>
+                                        <div class="tab-pane fade" id="register" role="tabpanel" aria-labelledby="register-tab">
+                                            <form id="register-form">
+                                                <div class="mb-3">
+                                                    <label for="register-username" class="form-label">Username</label>
+                                                    <input type="text" class="form-control" id="register-username" required>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label for="register-email" class="form-label">Email</label>
+                                                    <input type="email" class="form-control" id="register-email" required>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label for="register-password" class="form-label">Password</label>
+                                                    <input type="password" class="form-control" id="register-password" required>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label for="register-confirm-password" class="form-label">Confirm Password</label>
+                                                    <input type="password" class="form-control" id="register-confirm-password" required>
+                                                </div>
+                                                <div class="alert alert-danger d-none" id="register-error"></div>
+                                                <button type="submit" class="btn btn-primary w-100">Register</button>
+                                            </form>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -138,6 +138,28 @@ body {
 #auth-section .card {
     border-radius: 15px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+.auth-image {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    border-top-left-radius: 15px;
+    border-bottom-left-radius: 15px;
+}
+
+@media (min-width: 768px) {
+    #auth-section .card {
+        flex-direction: row;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .auth-image {
+        display: none;
+    }
 }
 
 .nav-tabs .nav-link {


### PR DESCRIPTION
## Summary
- add side-by-side login/register layout with image
- style auth image and card for responsive behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843da31d0e0832095af5a6b3aadc3fa