### PR TITLE
Add login-required decorator and cookie token

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory, jsonify
 from src.models.user import db
-from src.routes.user import user_bp
+from src.routes.user import user_bp, login_required
 from src.routes.expense import expense_bp
 from src.routes.budget import budget_bp
 from flask_cors import CORS
@@ -72,26 +72,31 @@ def register_page():
 
 
 @app.route('/dashboard')
+@login_required
 def dashboard_page():
     return send_from_directory(app.static_folder, 'dashboard.html')
 
 
 @app.route('/expenses')
+@login_required
 def expenses_page():
     return send_from_directory(app.static_folder, 'expenses.html')
 
 
 @app.route('/budgets')
+@login_required
 def budgets_page():
     return send_from_directory(app.static_folder, 'budgets.html')
 
 
 @app.route('/reports')
+@login_required
 def reports_page():
     return send_from_directory(app.static_folder, 'reports.html')
 
 
 @app.route('/profile')
+@login_required
 def profile_page():
     return send_from_directory(app.static_folder, 'profile.html')
 

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,13 +7,42 @@ let expenses = [];
 let budgets = [];
 let charts = {};
 
+// Cookie helpers
+function setCookie(name, value, days) {
+    let expires = "";
+    if (days) {
+        const date = new Date();
+        date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+        expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "") + expires + "; path=/";
+}
+
+function getCookie(name) {
+    const nameEQ = name + "=";
+    const ca = document.cookie.split(";");
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === " ") c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+}
+
+function eraseCookie(name) {
+    document.cookie = name + "=; Max-Age=-99999999; path=/";
+}
+
 // Initialize the application
 document.addEventListener("DOMContentLoaded", function () {
         API_URL = window.location.origin;
         setupEventListeners();
         updateCurrencySymbols();
-        token = localStorage.getItem("token");
-        if (token) { fetchUserProfile(); }
+        token = localStorage.getItem("token") || getCookie("token");
+        if (token) {
+            localStorage.setItem("token", token);
+            fetchUserProfile();
+        }
         const dashboardPage = document.getElementById("dashboard-page");
         const expensesPage = document.getElementById("expenses-page");
         const budgetsPage = document.getElementById("budgets-page");
@@ -121,6 +150,7 @@ function handleLogin(e) {
                         if (data.token) {
                                 // Save token and user data
                                 token = data.token;
+                                setCookie("token", token, 1);
                                 localStorage.setItem("token", token);
                                 currentUser = data.user;
                                 updateCurrencySymbols();
@@ -188,12 +218,13 @@ function handleRegister(e) {
 }
 
 function handleLogout(e) {
-	e.preventDefault();
+        e.preventDefault();
 
-	// Clear token and user data
-	token = null;
-	localStorage.removeItem("token");
-	currentUser = null;
+        // Clear token and user data
+        token = null;
+        localStorage.removeItem("token");
+        eraseCookie("token");
+        currentUser = null;
 
         window.location.href = "/login";
 }


### PR DESCRIPTION
## Summary
- add `login_required` decorator that checks cookies or headers
- protect static page routes with the decorator
- store JWT in a cookie on login and clear it on logout
- read token from cookie on page load

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844411381288320bcf0f655a258f69a