### PR TITLE
Fix missing dashboard loader

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -963,9 +963,26 @@ function initializeCharts() {
 				},
 			});
 		})
-		.catch((error) => {
-			console.error("Error loading chart data:", error);
-		});
+                .catch((error) => {
+                        console.error("Error loading chart data:", error);
+                });
+}
+
+// Load all data needed for the dashboard
+function loadDashboardData() {
+        return loadCategories()
+                .then(() =>
+                        Promise.all([
+                                loadDashboardSummary(),
+                                loadRecentExpenses(),
+                                loadBudgetStatus(),
+                        ])
+                )
+                .then(() => initializeCharts())
+                .catch((error) => {
+                        console.error("Error loading dashboard data:", error);
+                        showToast("Failed to load dashboard data", "error");
+                });
 }
 
 // Expense CRUD functions


### PR DESCRIPTION
## Summary
- implement `loadDashboardData` in `app.js`
- load dashboard data and charts when the dashboard is opened

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684446eb2fa08320ad77d75024726809