### PR TITLE
Fix duplicate script tags to prevent API_URL errors

### DIFF
--- a/src/static/budgets.html
+++ b/src/static/budgets.html
@@ -341,9 +341,3 @@
         <script src="/app.js"></script>
     </body>
 </html>
-</div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="/app.js"></script>
-</body>
-</html>

--- a/src/static/expenses.html
+++ b/src/static/expenses.html
@@ -365,9 +365,3 @@
         <script src="/app.js"></script>
     </body>
 </html>
-</div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="/app.js"></script>
-</body>
-</html>

--- a/src/static/reports.html
+++ b/src/static/reports.html
@@ -355,9 +355,3 @@
         <script src="/app.js"></script>
     </body>
 </html>
-</div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="/app.js"></script>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- remove duplicate `<script>` blocks from budgets, expenses and reports pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684449ec760c8320b5a4153d6635479f