### PR TITLE
Fix registration success redirect

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -199,7 +199,12 @@ function handleRegister(e) {
 			if (data.message === "User registered successfully") {
 				// Show success and switch to login tab
 				showToast("Registration successful! Please log in.", "success");
-				document.getElementById("login-tab").click();
+                                const loginTab = document.getElementById("login-tab");
+                                if (loginTab) {
+                                        loginTab.click();
+                                } else {
+                                        window.location.href = "/login";
+                                }
 			} else {
 				// Show error
 				const errorElement = document.getElementById("register-error");


### PR DESCRIPTION
## Summary
- avoid clicking missing login-tab on registration success
- gracefully redirect to login page if login-tab element doesn't exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452e13a5b08320af625e80a772f340