### PR TITLE
Fix Add Budget modal visibility

### DIFF
--- a/src/static/budgets.html
+++ b/src/static/budgets.html
@@ -103,8 +103,8 @@
                         </div>
                     </div>
 
-                    <!-- Reports Page -->
-                    <div id="reports-page" class="dashboard-page d-none">
+                    <!-- Modals -->
+                    <div id="modals-container">
             <!-- Add Expense Modal -->
             <div class="modal fade" id="addExpenseModal" tabindex="-1" aria-hidden="true">
                 <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- ensure the budget modal container is not hidden by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684536f486208320b856c674427d0a9c