### PR TITLE
Enable Flask-Migrate for database migrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ et_xmlfile==2.0.0
 fastapi==0.115.12
 Flask==3.1.1
 flask-cors==6.0.0
+Flask-SQLAlchemy==3.1.1
+Flask-Migrate==4.0.5
 fonttools==4.58.0
 fpdf==1.7.2
 fpdf2==2.8.3

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory, jsonify
 from src.models.user import db
+from flask_migrate import Migrate
 from src.routes.user import user_bp, login_required
 from src.routes.expense import expense_bp
 from src.routes.budget import budget_bp
@@ -34,6 +35,7 @@ app.config['SQLALCHEMY_DATABASE_URI'] = (
 )
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
+migrate = Migrate(app, db)
 
 # Create database tables
 with app.app_context():

--- a/todo.md
+++ b/todo.md
@@ -25,6 +25,7 @@
   - [x] Budget tracking interface
   - [x] Data visualization components
   - [x] Responsive design
+- [x] Integrate database migrations using Flask-Migrate
 - [x] Implement data visualization
   - [x] Expense breakdown charts
   - [x] Budget vs. actual spending

--- a/user_guide.md
+++ b/user_guide.md
@@ -104,8 +104,24 @@ The main dashboard provides a quick snapshot of your financial status:
 
 The Expense Calculator Web Dashboard is built using:
 - **Backend**: Flask (Python) with MySQL database
+- **Database ORM**: Flask-SQLAlchemy with migrations managed by Flask-Migrate
 - **Frontend**: HTML, CSS, JavaScript with Bootstrap framework
 - **Data Visualization**: Chart.js for interactive charts
+
+### Database Migrations
+After modifying a model, generate and apply a migration without dropping data:
+1. Set the application module:
+   ```bash
+   export FLASK_APP=src.main:app
+   ```
+2. Create a migration script:
+   ```bash
+   flask db migrate -m "describe change"
+   ```
+3. Apply the migration to your database:
+   ```bash
+   flask db upgrade
+   ```
 
 ## Support
 


### PR DESCRIPTION
## Summary
- add `Flask-SQLAlchemy` and `Flask-Migrate` dependencies
- initialize `Migrate` in the Flask app
- document migration commands in the user guide
- note completed migration setup in TODO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845496f01e48320b468f78c3931d530