### PR TITLE
Improve JWT error handling

### DIFF
--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -29,7 +29,9 @@ def token_required(f):
         try:
             data = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
             current_user = User.query.filter_by(id=data['user_id']).first()
-        except:
+        except jwt.ExpiredSignatureError:
+            return jsonify({'message': 'Token has expired!'}), 401
+        except jwt.InvalidTokenError:
             return jsonify({'message': 'Token is invalid!'}), 401
             
         return f(current_user, *args, **kwargs)


### PR DESCRIPTION
## Summary
- handle JWT invalid/expired token errors explicitly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c67ce85883209ae44914f60e58fd