### PR TITLE
Read config from env

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ from flask_cors import CORS
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 CORS(app)  # Enable CORS for all routes
-app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 # Register blueprints
 app.register_blueprint(user_bp, url_prefix='/api/user')
@@ -130,4 +130,6 @@ def server_error(e):
     return jsonify({"message": "Internal server error"}), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_env = os.getenv('DEBUG', 'False')
+    debug_mode = debug_env.lower() in ('1', 'true', 'yes', 'y', 't')
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)

--- a/user_guide.md
+++ b/user_guide.md
@@ -123,6 +123,13 @@ After modifying a model, generate and apply a migration without dropping data:
    flask db upgrade
    ```
 
+### Environment Variables
+
+Set the following variables before running the application:
+
+- `SECRET_KEY` – secret key used for Flask sessions and JWT tokens.
+- `DEBUG` – set to `True` to enable debug mode (defaults to `False`).
+
 ## Support
 
 If you encounter any issues or have questions about using the dashboard, please contact support.


### PR DESCRIPTION
## Summary
- load SECRET_KEY from the environment
- control debug mode via an environment variable
- add docs about the new variables

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c66877708320a905e2d855a7d8fe