### PR TITLE
Fix date defaults with callables

### DIFF
--- a/src/models/expense.py
+++ b/src/models/expense.py
@@ -25,7 +25,7 @@ class Expense(db.Model):
     amount = db.Column(db.Float, nullable=False)
     description = db.Column(db.String(255), nullable=True)
     payment_method = db.Column(db.String(20), nullable=True)
-    date = db.Column(db.Date, nullable=False, default=datetime.utcnow().date)
+    date = db.Column(db.Date, nullable=False, default=lambda: datetime.utcnow().date())
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey('categories.id'), nullable=False)

--- a/src/models/income.py
+++ b/src/models/income.py
@@ -9,7 +9,7 @@ class Income(db.Model):
     description = db.Column(db.String(255), nullable=True)
     income_type = db.Column(db.String(50), nullable=False)
     other_source = db.Column(db.String(100), nullable=True)
-    date = db.Column(db.Date, nullable=False, default=datetime.utcnow().date)
+    date = db.Column(db.Date, nullable=False, default=lambda: datetime.utcnow().date())
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
 

--- a/src/models/saving.py
+++ b/src/models/saving.py
@@ -7,7 +7,7 @@ class Saving(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     amount = db.Column(db.Float, nullable=False)
     description = db.Column(db.String(255), nullable=True)
-    date = db.Column(db.Date, nullable=False, default=datetime.utcnow().date)
+    date = db.Column(db.Date, nullable=False, default=lambda: datetime.utcnow().date())
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
 


### PR DESCRIPTION
## Summary
- use callables for default dates in Expense, Income, and Saving models

## Testing
- `flask db migrate -m "use callable for date default"`
- `flask db upgrade`


------
https://chatgpt.com/codex/tasks/task_e_6845c67afbd08320bb835a660174781f