### PR TITLE
Fix savings page routing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.routes.saving import saving_bp
 from flask_cors import CORS
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+app.url_map.strict_slashes = False  # Allow routes with or without trailing slash
 CORS(app)  # Enable CORS for all routes
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 


### PR DESCRIPTION
## Summary
- allow Flask routes to work with or without trailing slashes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845c990d6e88320a5f4a993e259546b