### PR TITLE
Add editable fields to user profile

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2538,12 +2538,38 @@ function showUserProfile(e) {
 	})
 		.then((response) => response.json())
                 .then((data) => {
-                        document.getElementById("profile-username").textContent = data.username;
-                        document.getElementById("profile-email").textContent = data.email;
-                        document.getElementById("profile-created").textContent = new Date(
-                                data.created_at
-                        ).toLocaleString();
-                        document.getElementById("profile-currency").value = data.currency || "USD";
+                        const usernameEl = document.getElementById("profile-username");
+                        if (usernameEl) {
+                                if (usernameEl.tagName === "INPUT") {
+                                        usernameEl.value = data.username;
+                                } else {
+                                        usernameEl.textContent = data.username;
+                                }
+                        }
+
+                        const emailEl = document.getElementById("profile-email");
+                        if (emailEl) {
+                                if (emailEl.tagName === "INPUT") {
+                                        emailEl.value = data.email;
+                                } else {
+                                        emailEl.textContent = data.email;
+                                }
+                        }
+
+                        const createdEl = document.getElementById("profile-created");
+                        if (createdEl) {
+                                createdEl.textContent = new Date(data.created_at).toLocaleString();
+                        }
+
+                        const currencyEl = document.getElementById("profile-currency");
+                        if (currencyEl) {
+                                currencyEl.value = data.currency || "USD";
+                        }
+
+                        const passwordEl = document.getElementById("profile-password");
+                        if (passwordEl && passwordEl.tagName === "INPUT") {
+                                passwordEl.value = "";
+                        }
 
                         const modalEl = document.getElementById("profileModal");
                         if (modalEl) {
@@ -2557,6 +2583,9 @@ function showUserProfile(e) {
 }
 
 function saveUserProfile() {
+        const username = document.getElementById("profile-username")?.value;
+        const email = document.getElementById("profile-email")?.value;
+        const password = document.getElementById("profile-password")?.value;
         const currency = document.getElementById("profile-currency").value;
 
         fetch(`${API_URL}/api/user/profile`, {
@@ -2565,7 +2594,7 @@ function saveUserProfile() {
                         "Content-Type": "application/json",
                         Authorization: `Bearer ${token}`,
                 },
-                body: JSON.stringify({ currency }),
+                body: JSON.stringify({ username, email, password, currency }),
         })
                 .then((response) => response.json())
                 .then((data) => {

--- a/src/static/profile.html
+++ b/src/static/profile.html
@@ -51,20 +51,24 @@
     </div>
     <div class="row">
         <div class="col-md-6">
-            <div class="mb-3">
-                <label class="form-label">Username:</label>
-                <span id="profile-username"></span>
+            <div class="form-floating mb-3">
+                <input type="text" class="form-control" id="profile-username" placeholder="Username">
+                <label for="profile-username"><i class="fas fa-user me-2"></i>Username</label>
+            </div>
+            <div class="form-floating mb-3">
+                <input type="email" class="form-control" id="profile-email" placeholder="Email">
+                <label for="profile-email"><i class="fas fa-envelope me-2"></i>Email</label>
+            </div>
+            <div class="form-floating mb-3">
+                <input type="password" class="form-control" id="profile-password" placeholder="Password">
+                <label for="profile-password"><i class="fas fa-lock me-2"></i>Password</label>
             </div>
             <div class="mb-3">
-                <label class="form-label">Email:</label>
-                <span id="profile-email"></span>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Joined:</label>
+                <label class="form-label"><i class="fas fa-calendar me-2"></i>Joined:</label>
                 <span id="profile-created"></span>
             </div>
             <div class="mb-3">
-                <label for="profile-currency" class="form-label">Currency</label>
+                <label for="profile-currency" class="form-label"><i class="fas fa-money-bill-wave me-2"></i>Currency</label>
                 <select class="form-select" id="profile-currency">
                     <option value="USD">$ USD</option>
                     <option value="EUR">€ EUR</option>


### PR DESCRIPTION
## Summary
- allow editing username, email and password on profile page
- populate profile page inputs from API
- send all profile fields to backend when saving changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845d54a03f0832092efe8aa704e96bc