### PR TITLE
Refactor profile modal to shared include

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory, jsonify
+from flask import Flask, send_from_directory, jsonify, render_template
 from src.models.user import db
 from flask_migrate import Migrate
 from src.routes.user import user_bp, login_required
@@ -17,7 +17,8 @@ from src.routes.income import income_bp
 from src.routes.saving import saving_bp
 from flask_cors import CORS
 
-app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+static_dir = os.path.join(os.path.dirname(__file__), 'static')
+app = Flask(__name__, static_folder=static_dir, template_folder=static_dir)
 app.url_map.strict_slashes = False  # Allow routes with or without trailing slash
 CORS(app)  # Enable CORS for all routes
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
@@ -67,57 +68,57 @@ with app.app_context():
 
 @app.route('/')
 def home():
-    return send_from_directory(app.static_folder, 'home.html')
+    return render_template('home.html')
 
 @app.route('/login')
 def login_page():
-    return send_from_directory(app.static_folder, 'login.html')
+    return render_template('login.html')
 
 @app.route('/register')
 def register_page():
-    return send_from_directory(app.static_folder, 'register.html')
+    return render_template('register.html')
 
 
 @app.route('/dashboard')
 @login_required
 def dashboard_page():
-    return send_from_directory(app.static_folder, 'dashboard.html')
+    return render_template('dashboard.html')
 
 
 @app.route('/expenses')
 @login_required
 def expenses_page():
-    return send_from_directory(app.static_folder, 'expenses.html')
+    return render_template('expenses.html')
 
 
 @app.route('/incomes')
 @login_required
 def incomes_page():
-    return send_from_directory(app.static_folder, 'incomes.html')
+    return render_template('incomes.html')
 
 
 @app.route('/savings')
 @login_required
 def savings_page():
-    return send_from_directory(app.static_folder, 'savings.html')
+    return render_template('savings.html')
 
 
 @app.route('/budgets')
 @login_required
 def budgets_page():
-    return send_from_directory(app.static_folder, 'budgets.html')
+    return render_template('budgets.html')
 
 
 @app.route('/reports')
 @login_required
 def reports_page():
-    return send_from_directory(app.static_folder, 'reports.html')
+    return render_template('reports.html')
 
 
 @app.route('/profile')
 @login_required
 def profile_page():
-    return send_from_directory(app.static_folder, 'profile.html')
+    return render_template('profile.html')
 
 
 @app.route('/<path:filename>')

--- a/src/static/budgets.html
+++ b/src/static/budgets.html
@@ -930,75 +930,9 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        
-                                        <!-- User Profile Modal -->
-                                        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-                                            <div class="modal-dialog">
-                                                <div class="modal-content">
-                                                    <div class="modal-header bg-info text-white">
-                                                        <h5 class="modal-title" id="profileModalLabel">
-                                                            <i class="fas fa-user-circle me-2"></i>User Profile
-                                                        </h5>
-                                                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        <div class="text-center mb-4">
-                                                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                                                <i class="fas fa-user fa-2x text-muted"></i>
-                                                            </div>
-                                                        </div>
-                                                        <div class="row">
-                                                            <div class="col-sm-4">
-                                                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                                                            </div>
-                                                            <div class="col-sm-8">
-                                                                <span id="profile-username">-</span>
-                                                            </div>
-                                                        </div>
-                                                        <hr>
-                                                        <div class="row">
-                                                            <div class="col-sm-4">
-                                                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                                                            </div>
-                                                            <div class="col-sm-8">
-                                                                <span id="profile-email">-</span>
-                                                            </div>
-                                                        </div>
-                                                        <hr>
-                                                        <div class="row">
-                                                            <div class="col-sm-4">
-                                                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                                                            </div>
-                                                            <div class="col-sm-8">
-                                                                <span id="profile-created">-</span>
-                                                            </div>
-                                                        </div>
-                                                        <hr>
-                                                        <div class="mb-3">
-                                                            <label for="profile-currency" class="form-label">
-                                                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                                                            </label>
-                                                            <select class="form-select" id="profile-currency">
-                                                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                                                            <i class="fas fa-times me-1"></i>Close
-                                                        </button>
-                                                        <button type="button" class="btn btn-info" id="save-profile">
-                                                            <i class="fas fa-save me-1"></i>Save Changes
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        
-                                        <!-- Confirmation Modal -->
+        {% include 'profile_modal.html' %}
+
+        <!-- Confirmation Modal -->
                                         <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalLabel" aria-hidden="true">
                                             <div class="modal-dialog">
                                                 <div class="modal-content">

--- a/src/static/dashboard.html
+++ b/src/static/dashboard.html
@@ -686,75 +686,9 @@
                 </div>
             </div>
         </div>
+    {% include 'profile_modal.html' %}
 
-        <!-- User Profile Modal -->
-        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header bg-info text-white">
-                        <h5 class="modal-title" id="profileModalLabel">
-                            <i class="fas fa-user-circle me-2"></i>User Profile
-                        </h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="text-center mb-4">
-                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                <i class="fas fa-user fa-2x text-muted"></i>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-username">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-email">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-created">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="mb-3">
-                            <label for="profile-currency" class="form-label">
-                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                            </label>
-                            <select class="form-select" id="profile-currency">
-                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            <i class="fas fa-times me-1"></i>Close
-                        </button>
-                        <button type="button" class="btn btn-info" id="save-profile">
-                            <i class="fas fa-save me-1"></i>Save Changes
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Loading Spinner Overlay -->
+    <!-- Loading Spinner Overlay -->
         <div id="loading-overlay" class="d-none"
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; display: flex; align-items: center; justify-content: center;">
             <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">

--- a/src/static/expenses.html
+++ b/src/static/expenses.html
@@ -776,75 +776,9 @@
                 </div>
             </div>
         </div>
+    {% include 'profile_modal.html' %}
 
-        <!-- User Profile Modal -->
-        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header bg-info text-white">
-                        <h5 class="modal-title" id="profileModalLabel">
-                            <i class="fas fa-user-circle me-2"></i>User Profile
-                        </h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="text-center mb-4">
-                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                <i class="fas fa-user fa-2x text-muted"></i>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-username">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-email">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-created">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="mb-3">
-                            <label for="profile-currency" class="form-label">
-                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                            </label>
-                            <select class="form-select" id="profile-currency">
-                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            <i class="fas fa-times me-1"></i>Close
-                        </button>
-                        <button type="button" class="btn btn-info" id="save-profile">
-                            <i class="fas fa-save me-1"></i>Save Changes
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Confirmation Modal -->
+    <!-- Confirmation Modal -->
         <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalLabel" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/src/static/incomes.html
+++ b/src/static/incomes.html
@@ -1015,75 +1015,9 @@
                 </div>
             </div>
         </div>
+    {% include 'profile_modal.html' %}
 
-        <!-- User Profile Modal -->
-        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header bg-info text-white">
-                        <h5 class="modal-title" id="profileModalLabel">
-                            <i class="fas fa-user-circle me-2"></i>User Profile
-                        </h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="text-center mb-4">
-                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                <i class="fas fa-user fa-2x text-muted"></i>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-username">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-email">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-created">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="mb-3">
-                            <label for="profile-currency" class="form-label">
-                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                            </label>
-                            <select class="form-select" id="profile-currency">
-                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            <i class="fas fa-times me-1"></i>Close
-                        </button>
-                        <button type="button" class="btn btn-info" id="save-profile">
-                            <i class="fas fa-save me-1"></i>Save Changes
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Loading Spinner Overlay -->
+    <!-- Loading Spinner Overlay -->
         <div id="loading-overlay" class="d-none"
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; display: flex; align-items: center; justify-content: center;">
             <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">

--- a/src/static/profile_modal.html
+++ b/src/static/profile_modal.html
@@ -1,0 +1,66 @@
+                                        <!-- User Profile Modal -->
+                                        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                    <div class="modal-header bg-info text-white">
+                                                        <h5 class="modal-title" id="profileModalLabel">
+                                                            <i class="fas fa-user-circle me-2"></i>User Profile
+                                                        </h5>
+                                                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <div class="text-center mb-4">
+                                                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
+                                                                <i class="fas fa-user fa-2x text-muted"></i>
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-sm-4">
+                                                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
+                                                            </div>
+                                                            <div class="col-sm-8">
+                                                                <span id="profile-username">-</span>
+                                                            </div>
+                                                        </div>
+                                                        <hr>
+                                                        <div class="row">
+                                                            <div class="col-sm-4">
+                                                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
+                                                            </div>
+                                                            <div class="col-sm-8">
+                                                                <span id="profile-email">-</span>
+                                                            </div>
+                                                        </div>
+                                                        <hr>
+                                                        <div class="row">
+                                                            <div class="col-sm-4">
+                                                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
+                                                            </div>
+                                                            <div class="col-sm-8">
+                                                                <span id="profile-created">-</span>
+                                                            </div>
+                                                        </div>
+                                                        <hr>
+                                                        <div class="mb-3">
+                                                            <label for="profile-currency" class="form-label">
+                                                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
+                                                            </label>
+                                                            <select class="form-select" id="profile-currency">
+                                                                <option value="USD">🇺🇸 USD - US Dollar</option>
+                                                                <option value="EUR">🇪🇺 EUR - Euro</option>
+                                                                <option value="GBP">🇬🇧 GBP - British Pound</option>
+                                                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="modal-footer">
+                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                                                            <i class="fas fa-times me-1"></i>Close
+                                                        </button>
+                                                        <button type="button" class="btn btn-info" id="save-profile">
+                                                            <i class="fas fa-save me-1"></i>Save Changes
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>

--- a/src/static/reports.html
+++ b/src/static/reports.html
@@ -1017,75 +1017,9 @@
                 </div>
             </div>
         </div>
+    {% include 'profile_modal.html' %}
 
-        <!-- User Profile Modal -->
-        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header bg-info text-white">
-                        <h5 class="modal-title" id="profileModalLabel">
-                            <i class="fas fa-user-circle me-2"></i>User Profile
-                        </h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="text-center mb-4">
-                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                <i class="fas fa-user fa-2x text-muted"></i>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-username">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-email">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-created">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="mb-3">
-                            <label for="profile-currency" class="form-label">
-                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                            </label>
-                            <select class="form-select" id="profile-currency">
-                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            <i class="fas fa-times me-1"></i>Close
-                        </button>
-                        <button type="button" class="btn btn-info" id="save-profile">
-                            <i class="fas fa-save me-1"></i>Save Changes
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Confirmation Modal -->
+    <!-- Confirmation Modal -->
         <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalLabel" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/src/static/savings.html
+++ b/src/static/savings.html
@@ -1109,75 +1109,9 @@
                 </div>
             </div>
         </div>
+    {% include 'profile_modal.html' %}
 
-        <!-- User Profile Modal -->
-        <div class="modal fade" id="profileModal" tabindex="-1" aria-labelledby="profileModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header bg-info text-white">
-                        <h5 class="modal-title" id="profileModalLabel">
-                            <i class="fas fa-user-circle me-2"></i>User Profile
-                        </h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="text-center mb-4">
-                            <div class="bg-light rounded-circle d-inline-flex align-items-center justify-content-center" style="width: 80px; height: 80px;">
-                                <i class="fas fa-user fa-2x text-muted"></i>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-user me-2"></i>Username:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-username">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-envelope me-2"></i>Email:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-email">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <strong><i class="fas fa-calendar me-2"></i>Joined:</strong>
-                            </div>
-                            <div class="col-sm-8">
-                                <span id="profile-created">-</span>
-                            </div>
-                        </div>
-                        <hr>
-                        <div class="mb-3">
-                            <label for="profile-currency" class="form-label">
-                                <strong><i class="fas fa-money-bill-wave me-2"></i>Currency</strong>
-                            </label>
-                            <select class="form-select" id="profile-currency">
-                                <option value="USD">🇺🇸 USD - US Dollar</option>
-                                <option value="EUR">🇪🇺 EUR - Euro</option>
-                                <option value="GBP">🇬🇧 GBP - British Pound</option>
-                                <option value="LKR">🇱🇰 LKR - Sri Lankan Rupee</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            <i class="fas fa-times me-1"></i>Close
-                        </button>
-                        <button type="button" class="btn btn-info" id="save-profile">
-                            <i class="fas fa-save me-1"></i>Save Changes
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Loading Spinner Overlay -->
+    <!-- Loading Spinner Overlay -->
         <div id="loading-overlay" class="d-none"
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; display: flex; align-items: center; justify-content: center;">
             <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">


### PR DESCRIPTION
## Summary
- centralize the profile modal markup in `profile_modal.html`
- switch Flask routes to render templates from the static folder
- replace inline modal markup in page templates with `{% include 'profile_modal.html' %}`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845d55906ec832085fefcfacde356d4