### PR TITLE
Create base template for shared layout

### DIFF
--- a/convert_html.awk
+++ b/convert_html.awk
@@ -1,0 +1,33 @@
+BEGIN {
+    title = TITLE
+    print "{% extends 'base.html' %}"
+    print "{% block title %}" title "{% endblock %}"
+    skip = 1
+}
+/<style>/ {
+    print "{% block extra_head %}"
+    print
+    in_style = 1
+    skip = 0
+    next
+}
+/<\/style>/ {
+    print
+    print "{% endblock %}"
+    in_style = 0
+    next
+}
+{ if(in_style) {print; next} }
+/<head>/ {next}
+/<\/head>/ {next}
+/^<!DOCTYPE html>/ {next}
+/^<html/ {next}
+/<body>/ {print "{% block content %}"; next}
+/{% include 'navbar.html' %}/ {next}
+/bootstrap\.bundle\.min\.js/ {print "{% endblock %}\n{% block extra_scripts %}"; scripts=1; next}
+/chart\.js/ {next}
+/\/app\.js/ {next}
+/<\/script>/ && scripts {print; print "{% endblock %}"; scripts=0; next}
+/<\/body>/ {next}
+/<\/html>/ {next}
+{ if(!skip && !in_style) print }

--- a/src/static/base.html
+++ b/src/static/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{% block title %}Expense Tracker{% endblock %}</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+        <link rel="stylesheet" href="/styles.css">
+        {% block extra_head %}{% endblock %}
+    </head>
+    <body>
+        {% if hide_navbar is not defined or not hide_navbar %}
+            {% include 'navbar.html' %}
+        {% endif %}
+        {% block content %}{% endblock %}
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <script src="/app.js"></script>
+        {% block extra_scripts %}{% endblock %}
+    </body>
+</html>

--- a/src/static/budgets.html
+++ b/src/static/budgets.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Budgets - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Budgets - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Additional budgets-specific styles */
             .page-header {
@@ -371,10 +365,9 @@
                 animation: pulse 2s infinite;
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="budgets-page">
@@ -906,9 +899,8 @@
                                         </div>
                                         
                                         <!-- Scripts -->
-                                        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-                                        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-                                        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
                                         
                                         <script>
                                             // Enhanced budgets-specific functionality
@@ -1577,5 +1569,4 @@
                                                             return insights;
                                                         };
                                                     </script>
-        </body>
-        </html>
+{% endblock %}

--- a/src/static/dashboard.html
+++ b/src/static/dashboard.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Dashboard - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Dashboard - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Additional dashboard-specific styles */
             .metric-card {
@@ -142,10 +136,9 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="dashboard-page">
@@ -637,9 +630,8 @@
         </div>
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
 
         <script>
             // Additional dashboard-specific functionality
@@ -769,5 +761,4 @@
                 }
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/expenses.html
+++ b/src/static/expenses.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Expenses - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Expenses - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Additional expenses-specific styles */
             .page-header {
@@ -232,10 +226,9 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="expenses-page">
@@ -752,9 +745,8 @@
         </div>
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
 
         <script>
             // Additional expenses-specific functionality
@@ -1023,5 +1015,4 @@
                 showToast('An unexpected error occurred. Please refresh the page.', 'error');
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/home.html
+++ b/src/static/home.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Expense Tracker - Smart Financial Management</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% set hide_navbar = True %}
+{% block title %}Expense Tracker - Smart Financial Management{% endblock %}
+{% block extra_head %}
         <style>
             /* Additional styles for enhanced home page */
             .hero-section {
@@ -159,8 +154,8 @@
                 border-radius: 2px;
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-transparent">
             <div class="container">
@@ -453,7 +448,8 @@
             </div>
         </footer>
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+{% block extra_scripts %}
         <script>
             // Smooth scrolling for navigation links
             document.addEventListener('DOMContentLoaded', function () {
@@ -529,5 +525,4 @@
                 }
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/incomes.html
+++ b/src/static/incomes.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Incomes - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Incomes - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Advanced incomes-specific styles */
             :root {
@@ -605,10 +599,9 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="incomes-page">
@@ -966,8 +959,8 @@
         </div>
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
 
         <script>
             // Additional incomes-specific functionality
@@ -1154,8 +1147,8 @@
                     return `
                     <!DOCTYPE html>
                     <html>
-                    <head>
                         <title>Income Report</title>
+{% block extra_head %}
                         <style>
                             body { font-family: Arial, sans-serif; margin: 20px; }
                             h1 { color: #28a745; text-align: center; }
@@ -1164,8 +1157,8 @@
                             th { background-color: #28a745; color: white; }
                             .total { font-weight: bold; background-color: #f8f9fa; }
                         </style>
-                    </head>
-                    <body>
+{% endblock %}
+{% block content %}
                         <h1>Income Report</h1>
                         <p>Generated on: ${new Date().toLocaleDateString()}</p>
                         <table>
@@ -1192,8 +1185,6 @@
                                 </tr>
                             </tbody>
                         </table>
-                    </body>
-                    </html>
                 `;
                 }
 
@@ -1379,5 +1370,4 @@
                 showToast('An unexpected error occurred. Please refresh the page.', 'error');
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Login - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% set hide_navbar = True %}
+{% block title %}Login - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Enhanced Login Page Styles */
             body {
@@ -361,8 +356,8 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Back to Home Button -->
         <div class="back-home">
             <a href="/">
@@ -444,8 +439,8 @@
             </div>
         </div>
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
         <script>
             // Enhanced login functionality
             document.addEventListener('DOMContentLoaded', function () {
@@ -601,5 +596,4 @@
                 });
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/profile.html
+++ b/src/static/profile.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Expense Tracker</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Expense Tracker{% endblock %}
+{% block extra_head %}
     <style>
         /* Profile page header styling */
         .page-header {
@@ -31,9 +25,8 @@
             transform: rotate(45deg);
         }
     </style>
-</head>
-<body>
-{% include 'navbar.html' %}
+{% endblock %}
+{% block content %}
 <!-- Main Content -->
 <div class="container mt-4" id="profile-page">
     <div class="page-header">
@@ -80,8 +73,5 @@
         </button>
     </form>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="/app.js"></script>
-</body>
-</html>
+{% endblock %}
+{% block extra_scripts %}

--- a/src/static/register.html
+++ b/src/static/register.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Register - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% set hide_navbar = True %}
+{% block title %}Register - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Enhanced Register Page Styles */
             body {
@@ -494,8 +489,8 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Back to Home Button -->
         <div class="back-home">
             <a href="/">
@@ -621,8 +616,8 @@
             </div>
         </div>
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
         <script>
             // Enhanced registration functionality
             document.addEventListener('DOMContentLoaded', function () {
@@ -950,5 +945,4 @@
                 });
             });
         </script>
-    </body>
-</html>
+{% endblock %}

--- a/src/static/reports.html
+++ b/src/static/reports.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Reports - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Reports - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Additional reports-specific styles */
             .page-header {
@@ -435,10 +429,9 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="reports-page">
@@ -1012,9 +1005,8 @@
         </div>
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
 
         <script>
             // Enhanced reports-specific functionality
@@ -1741,8 +1733,7 @@
                 });
             };
         </script>
-    </body>
-</html>
+{% endblock %}
 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
     <i class="fas fa-times me-1"></i>Cancel
 </button>

--- a/src/static/savings.html
+++ b/src/static/savings.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Savings - Expense Tracker</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <link rel="stylesheet" href="/styles.css">
+{% extends 'base.html' %}
+{% block title %}Savings - Expense Tracker{% endblock %}
+{% block extra_head %}
         <style>
             /* Advanced savings-specific styles */
             :root {
@@ -663,10 +657,9 @@
                 }
             }
         </style>
-    </head>
-    <body>
+{% endblock %}
+{% block content %}
         <!-- Navigation -->
-        {% include 'navbar.html' %}
 
         <!-- Main Content -->
         <div class="container-fluid mt-4" id="savings-page">
@@ -1060,8 +1053,8 @@
         </div>
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="/app.js"></script>
+{% endblock %}
+{% block extra_scripts %}
 
         <script>
             // Additional savings-specific functionality
@@ -1226,8 +1219,8 @@
                     return `
                                                     <!DOCTYPE html>
                                                     <html>
-                                                    <head>
                                                         <title>Savings Report</title>
+{% block extra_head %}
                                                         <style>
                                                             body { font-family: Arial, sans-serif; margin: 20px; }
                                                             h1 { color: #6f42c1; text-align: center; }
@@ -1236,8 +1229,8 @@
                                                             th { background-color: #6f42c1; color: white; }
                                                             .total { font-weight: bold; background-color: #f8f9fa; }
                                                         </style>
-                                                    </head>
-                                                    <body>
+{% endblock %}
+{% block content %}
                                                         <h1>Savings Report</h1>
                                                         <p>Generated on: ${new Date().toLocaleDateString()}</p>
                                                         <table>
@@ -1262,8 +1255,6 @@
                                                                 </tr>
                                                             </tbody>
                                                         </table>
-                                                    </body>
-                                                    </html>
                                                 `;
                 }
 
@@ -1708,5 +1699,4 @@
                         showToast('An unexpected error occurred. Please refresh the page.', 'error');
                     });
         </script>
-    </body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `base.html` template for shared head and navbar
- convert page templates to extend from `base.html`
- keep login-related pages from showing the navbar by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ec8dd92c8320bc87c7bcadba402b